### PR TITLE
fix(boss): Fix attack success calculation

### DIFF
--- a/MyApplication/app/src/main/java/com/example/myapplication/presentation/ui/BossFightActivity.java
+++ b/MyApplication/app/src/main/java/com/example/myapplication/presentation/ui/BossFightActivity.java
@@ -422,8 +422,9 @@ public class BossFightActivity extends AppCompatActivity {
         layoutActiveEquipment.addView(noEq);
     }
 
+// U BossFightActivity.java
+
     private void loadUserSuccessChance(String userId) {
-        // Koristimo istu metodu za dohvatanje zadataka kao i pre
         taskRepository.getAllTasks(userId, new TaskRepository.OnTasksLoadedListener() {
             @Override
             public void onSuccess(List<Task> allTasks) {
@@ -433,25 +434,21 @@ public class BossFightActivity extends AppCompatActivity {
                     return;
                 }
 
-                // Nema više potrebe za AtomicInteger, koristimo obične brojače
                 int total = 0;
                 int completed = 0;
 
-                // Prolazimo kroz sve zadatke
                 for (Task task : allTasks) {
-                    // Preskačemo pauzirane i otkazane, kao i pre
+                    // Preskačemo pauzirane i otkazane. Svi ostali ulaze u 'total'.
                     if (task.getStatus() == TaskStatus.PAUZIRAN || task.getStatus() == TaskStatus.OTKAZAN) {
                         continue;
                     }
 
-                    // KLJUČNA PROMENA: Proveravamo samo "pečat"!
-                    // Nema više komplikovanih asinhronih poziva odavde.
-                    if (task.isCountsForSuccess()) {
-                        total++;
-                        // Proveravamo da li je zadatak zaista rešen da bismo ga brojali u 'completed'
-                        if (task.getCompletionDate() != null) {
-                            completed++;
-                        }
+                    // Svi zadaci koji nisu preskočeni se broje u 'total'.
+                    total++;
+
+                    // A u 'completed' se broje samo oni koji su uspešni I nisu preko kvote.
+                    if (task.isCountsForSuccess() && task.getCompletionDate() != null) {
+                        completed++;
                     }
                 }
 


### PR DESCRIPTION
Obračun procenta uspešnosti je bio netačan jer je u ukupan broj zadataka (`total`) pogrešno brojao samo one koji nisu prešli kvotu (`countsForSuccess: true`). Ovo je dovodilo do netačnog imenioca u razlomku (npr. 2/3 umesto 2/4).

Logika u metodi `loadUserSuccessChance` je ispravljena tako da `total` brojač sada ispravno uključuje sve zadatke koji nisu pauzirani ili otkazani, bez obzira na njihov `countsForSuccess` status, što je u skladu sa definisanim pravilima. `completed` brojač i dalje ispravno broji samo uspešne zadatke koji nisu prešli kvotu.